### PR TITLE
Added support for environment-specific default values

### DIFF
--- a/lib/envm/env_var.rb
+++ b/lib/envm/env_var.rb
@@ -2,27 +2,37 @@ require "envm/config"
 
 module Envm
   class EnvVar
-    attr_accessor :name, :description, :default_value, :required_environments
+    attr_accessor :name, :description, :default_values, :required_environments
 
-    def initialize(name:, description: nil, default_value: nil, required: [])
+    def initialize(name:, description: nil, default_values: nil, set_value_required: [])
       self.name = name
       self.description = description
-      self.default_value = default_value
 
-      if required.respond_to?(:include?)
-        self.required_environments = required
+      if set_value_required.respond_to?(:include?)
+        self.required_environments = set_value_required
       else
         self.required_environments = []
-        self.required_environments << DEFAULT_ENV if required
+        self.required_environments << "all" if set_value_required == true
+      end
+
+      if default_values && default_values.is_a?(Hash)
+        self.default_values = default_values
+      else
+        self.default_values = {}
+        self.default_values['fallback_value'] = default_values
       end
     end
 
     def value
-      if required_environments.include?(Config.environment)
+      if required_environments.include?(Config.environment) || required_environments.include?("all")
         system_value or fail(NotSetError, "'#{name}' environment variable was required but not set on system.")
       else
-        system_value || default_value
+        system_value || default_value_for_env
       end
+    end
+
+    def default_value_for_env
+      default_values[Config.environment] ? default_values[Config.environment] : default_values['fallback_value']
     end
 
     def system_value

--- a/lib/envm/manifest_loader.rb
+++ b/lib/envm/manifest_loader.rb
@@ -13,8 +13,8 @@ module Envm
         current_var = EnvVar.new(
             name: key,
             description: env_attrs["description"],
-            default_value: env_attrs["default"],
-            required: env_attrs["required"],
+            default_values: env_attrs["default"],
+            set_value_required: env_attrs["set_value_required"],
         )
 
         vars[key] = current_var

--- a/spec/fixtures/env.yml
+++ b/spec/fixtures/env.yml
@@ -2,21 +2,29 @@ DATABASE_URL:
   default: "mysql2://app@127.0.0.1:3306/mydb"
   description: "Database connection string"
 AWS_ACCESS_KEY_ID:
-  required: true
+  set_value_required: true
   description: "Public key for your AWS account."
 AWS_SECRET_ACCESS_KEY:
-  required: true
+  set_value_required: true
   description: "Secret key for your AWS account."
 REQUIRED_WITH_DEFAULT:
   default: "mysql"
-  required: true
+  set_value_required: true
+  description: "required env var with default"
+MULTIPLE_DEFAULT_VALUES:
+  default:
+    development: "development_default"
+    staging: "staging_default"
+    production: "production_default"
+  set_value_required:
+    - "production"
   description: "required env var with default"
 REQUIRED_ON_PROD:
-  required:
+  set_value_required:
     - "production"
   description: "required env var only on production environment"
 REQUIRED_WITH_DEFAULT_ON_PROD:
   default: "default"
-  required:
+  set_value_required:
     - "production"
   description: "required env var with default only on production environment"


### PR DESCRIPTION
Added support for environment-specific default values.  
If one default value is provided, it is used for all environments (except environments that require a set value).
If a set value is required, it will return an error if not set (regardless if there is a default value).

@chrisledet please review.
