### PR TITLE
Add required and missing

### DIFF
--- a/lib/envm/env_var.rb
+++ b/lib/envm/env_var.rb
@@ -2,12 +2,13 @@ require "envm/config"
 
 module Envm
   class EnvVar
-    attr_accessor :name, :description, :default_value, :required_environments
+    attr_accessor :name, :description, :default_value, :required_environments, :env
 
-    def initialize(name:, description: nil, default_value: nil, required: [])
+    def initialize(name:, description: nil, default_value: nil, required: [], env: ENV)
       self.name = name
       self.description = description
       self.default_value = default_value
+      self.env = env
 
       if required.respond_to?(:include?)
         self.required_environments = required

--- a/lib/envm/env_var.rb
+++ b/lib/envm/env_var.rb
@@ -18,16 +18,20 @@ module Envm
       end
     end
 
+    def required_and_missing?
+      required_environments.include?(Config.environment) && !system_value
+    end
+
     def value
-      if required_environments.include?(Config.environment)
-        system_value or fail(NotSetError, "'#{name}' environment variable was required but not set on system.")
-      else
-        system_value || default_value
+      if required_and_missing?
+        fail(NotSetError, "'#{name}' environment variable was required but not set on system.")
       end
+
+      system_value || default_value
     end
 
     def system_value
-      ENV[name]
+      env[name]
     end
   end
 end

--- a/lib/envm/manifest.rb
+++ b/lib/envm/manifest.rb
@@ -4,8 +4,9 @@ require "envm/env_var"
 
 module Envm
   class Manifest
-    def initialize
-      @env_vars = ManifestLoader.load
+    def initialize(env = ENV)
+      @env_vars = ManifestLoader.load(env)
+    end
     end
 
     def fetch(name)

--- a/lib/envm/manifest.rb
+++ b/lib/envm/manifest.rb
@@ -7,6 +7,11 @@ module Envm
     def initialize(env = ENV)
       @env_vars = ManifestLoader.load(env)
     end
+
+    def missing_required_vars
+      @env_vars.each_with_object([]) do |(_, env_var), missing_vars|
+        missing_vars << env_var if env_var.required_and_missing?
+      end
     end
 
     def fetch(name)

--- a/lib/envm/manifest_loader.rb
+++ b/lib/envm/manifest_loader.rb
@@ -3,7 +3,7 @@ require "envm/parser"
 
 module Envm
   class ManifestLoader
-    def self.load
+    def self.load(env)
       contents = parser.parse
 
       vars = {}
@@ -15,6 +15,7 @@ module Envm
             description: env_attrs["description"],
             default_value: env_attrs["default"],
             required: env_attrs["required"],
+            env: env,
         )
 
         vars[key] = current_var

--- a/spec/envm/env_var_spec.rb
+++ b/spec/envm/env_var_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Envm::EnvVar do
+  describe "#required_and_missing?" do
+    let(:env) { {} }
+
+    subject(:env_var) do
+      described_class.new(
+        name: 'A_KEY',
+        required: required_environments,
+        env: env,
+      )
+    end
+
+    before do
+      allow(Envm::Config).to receive(:environment) { "test_env" }
+    end
+
+    context "when the required enviroment matches the Config.environment" do
+      let(:required_environments) { ["test_env"] }
+
+      context "when the key is missing from the ENV hash" do
+        it "should return true" do
+          expect(env_var).to be_required_and_missing
+        end
+      end
+
+      context "when the key is present from the ENV hash" do
+        let(:env) { { 'A_KEY' => "present" } }
+
+        it "should return false" do
+          expect(env_var).to_not be_required_and_missing
+        end
+      end
+    end
+
+    context "when the required enviroment matches the Config.environment" do
+      let(:required_environments) { ["another_env"] }
+
+      context "when the key is missing from the ENV hash" do
+        it "should return false" do
+          expect(env_var).to_not be_required_and_missing
+        end
+      end
+
+      context "when the key is present from the ENV hash" do
+        let(:env) { { 'A_KEY' => "present" } }
+
+        it "should return false" do
+          expect(env_var).to_not be_required_and_missing
+        end
+      end
+    end
+  end
+end

--- a/spec/envm/loader_spec.rb
+++ b/spec/envm/loader_spec.rb
@@ -4,8 +4,10 @@ describe Envm::ManifestLoader do
   end
 
   describe '#load' do
+    let(:env) { ENV }
+
     it 'returns key value of vars' do
-      loaded_vars = described_class.load
+      loaded_vars = described_class.load(env)
       expect(loaded_vars["DATABASE_URL"]).to_not be_nil
       expect(loaded_vars["AWS_ACCESS_KEY_ID"]).to_not be_nil
 


### PR DESCRIPTION
## Context

I want to leverage `envm` in a new lightweight deploy script for our other little app so we verify the required env vars on staging/production are set before triggering the deploy. The biggest change is the `Envm::Manifest#missing_required_vars`, since I'll be initializing `Envm::Manifest` with the env vars from staging/production.

@jennielouie @chrisledet @jeffrafter Please CR!